### PR TITLE
Bugfix for *.hk & *.tw domains

### DIFF
--- a/gfwlist2pac/resources/proxy.pac
+++ b/gfwlist2pac/resources/proxy.pac
@@ -12,19 +12,15 @@ var hasOwnProperty = Object.hasOwnProperty;
 function FindProxyForURL(url, host) {
     var suffix;
     var pos = host.lastIndexOf('.');
-    pos = host.lastIndexOf('.', pos - 1);
     while(1) {
-        if (pos <= 0) {
-            if (hasOwnProperty.call(domains, host)) {
-                return proxy;
-            } else {
-                return direct;
-            }
-        }
         suffix = host.substring(pos + 1);
         if (hasOwnProperty.call(domains, suffix)) {
             return proxy;
         }
+        if (pos <= 0) {
+            break;
+        }
         pos = host.lastIndexOf('.', pos - 1);
     }
+    return direct;
 }


### PR DESCRIPTION
e.g. http://www.discuss.com.hk/ would return `direct`.
Fix bug in the pr yesterday.